### PR TITLE
Force less version to 1.7.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "css"
   ],
   "dependencies": {
-    "less": "*"
+    "less": "1.7.5"
   },
   "devDependencies": {
     "express": "3.x",


### PR DESCRIPTION
New versions of https://github.com/less/less.js/blob/master/CHANGELOG.md are changing the way Parser() is constructed and break express-less.

This force the lib to use the latest compatible version of less -- a better solution would probably be to update your code to use less 2.0.0.
