### PR TITLE
Fix express deprecation warning

### DIFF
--- a/lib/express-less.js
+++ b/lib/express-less.js
@@ -71,7 +71,7 @@ module.exports = function(root, options) {
                         less.writeError(err);
                     }
 
-                    return res.send(500);
+                    return res.sendStatus(500);
                 }
 
                 res.set('Content-Type', 'text/css');


### PR DESCRIPTION
```
express deprecated res.send(status): Use res.sendStatus(status) instead ../express-less/lib/express-less.js:74:32
```